### PR TITLE
[🎨 UI/UX] 마이 페이지, 미리보기 페이지 퍼블리싱

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["basewhite", "Noto", "Segoe"]
+}

--- a/src/app/(home)/loading/page.tsx
+++ b/src/app/(home)/loading/page.tsx
@@ -1,0 +1,16 @@
+import React, { JSX } from "react";
+
+export default function MyPage(): JSX.Element {
+  return (
+    <div className="flex flex-col items-center justify-center gap-[90px] relative bg-gray-50 min-h-screen">
+      <main className="flex flex-col w-full max-w-[700px] items-center gap-4 text-center relative flex-[0_0_auto]">
+        <h1 className="font-bold text-2xl text-gray-800">
+          방금 만든 이야기로 뉴스를 만들고 있어요!
+        </h1>
+        <h2 className="text-gray-600 font-normal">
+          약 2분정도 소요될 예정이니, 화면을 끄지 말고 기다려주세요.
+        </h2>
+      </main>
+    </div>
+  );
+}

--- a/src/app/(home)/mypage/page.tsx
+++ b/src/app/(home)/mypage/page.tsx
@@ -1,0 +1,52 @@
+import { Card, CardContent } from "@/src/components/ui/card/card";
+import React, { JSX } from "react";
+
+export default function MyPage(): JSX.Element {
+  return (
+    <div className="flex flex-col items-center justify-center gap-[90px] relative bg-purple-6 min-h-screen">
+      <main className="flex flex-col w-full max-w-[700px] items-center gap-6 relative flex-[0_0_auto]">
+        <h1 className="font-bold-24 text-gray-5 font-bold text-[length:var(--bold-24-font-size)] tracking-[var(--bold-24-letter-spacing)] leading-[var(--bold-24-line-height)] self-start">
+          마이페이지
+        </h1>
+        <Card className="w-[700px] bg-white rounded-2xl border border-solid border-gray-1 shadow-[0px_1px_8px_2px_#0000000a] mx-auto">
+          <CardContent className="flex flex-col w-full px-6 py-6">
+            <div className="flex flex-col mb-10">
+              <div className="text-gray-5 font-bold mb-2">이름</div>
+              <div className="text-gray-5">지민영</div>
+            </div>
+            <div className="flex flex-col mb-10">
+              <div className="text-gray-5 font-bold mb-2">전화번호</div>
+              <div className="text-gray-5">010-1234-1234</div>
+            </div>
+            <div className="flex flex-col mb-10">
+              <div className="text-gray-5 font-bold mb-2">구독정보</div>
+              <div className="text-gray-5 mb-1">프리미엄 회원 : 2025.12.31</div>
+              <button className="w-[150px] h-[40px] bg-black rounded-lg text-white hover:bg-purple-2 flex items-center justify-center">
+                토스 결제하기
+              </button>
+            </div>
+
+            <div className="w-full h-px bg-gray-4 my-4"></div>
+            <div className="flex flex-col mb-4">
+              <div className="text-gray-5 font-bold mb-4">링크</div>
+              <div className="flex items-center">
+                <div className="text-gray-5 font-medium mr-4">유튜브</div>
+                <button className="w-[300px] h-[40px] bg-white border-2 border-red-500 text-red-500 rounded-lg hover:bg-red-50 flex items-center justify-center">
+                  연동해제
+                </button>
+              </div>
+            </div>
+            <div className="flex items-center mb-4">
+              <div className="text-gray-5 font-medium mr-4">비메오</div>
+              <button className="w-[300px] h-[40px] bg-black rounded-lg text-white hover:bg-purple-2 flex items-center justify-center">
+                연동하기
+              </button>
+            </div>
+            <div className="w-full h-px bg-gray-4 my-4"></div>
+            <div className="text-gray-5 font-bold mb-2">회원탈퇴</div>
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,75 +1,80 @@
 "use client"; // ✅ 클라이언트 컴포넌트 지정
 
 import {
-    NavigationMenu,
-    NavigationMenuItem,
-    NavigationMenuLink,
-    NavigationMenuList,
+  NavigationMenu,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
 } from "@/src/components/common/navigation-menu";
 import React, { JSX } from "react";
 import Image from "next/image";
+import Link from "next/link";
 
 const navigationItems = [
-    { id: "dashboard", label: "대시보드", active: true },
-    { id: "statistics", label: "통계", active: false },
+  { id: "dashboard", label: "대시보드", active: true },
+  { id: "statistics", label: "통계", active: false },
 ];
 
 const Header = (): JSX.Element => {
-    return (
-        <header className="flex flex-col items-center w-full border-b border-[#ECECEC]">
-            <div className="w-full h-[100px] bg-basewhite border-b border-[#ECECEC]">
-                <div className="container flex items-center justify-between h-full max-w-[1200px] mx-auto px-4">
-                    <div className="flex items-center gap-11">
-                        {/* Logo */}
-                        <Image
-                            alt="AINEWS"
-                            src="/images/logo.png"
-                            width={127}
-                            height={24}
-                            priority
-                        />
+  return (
+    <header className="flex flex-col items-center w-full border-b border-[#ECECEC]">
+      <div className="w-full h-[100px] bg-basewhite border-b border-[#ECECEC]">
+        <div className="container flex items-center justify-between h-full max-w-[1200px] mx-auto px-4">
+          <div className="flex items-center gap-11">
+            {/* Logo */}
+            <Link href="/">
+              <Image
+                alt="AINEWS"
+                src="/images/logo.png"
+                width={127}
+                height={24}
+                priority
+              />
+            </Link>
 
-                        {/* Navigation */}
-                        <NavigationMenu>
-                            <NavigationMenuList className="flex gap-11 flex-nowrap">
-                                {navigationItems.map((item) => (
-                                    <NavigationMenuItem key={item.id} className="relative">
-                                        <NavigationMenuLink
-                                            href={`#${item.id}`}
-                                            className="text-gray-5 font-bold text-[24px]"
-                                        >
-                                            {item.label}
-                                        </NavigationMenuLink>
-                                    </NavigationMenuItem>
-                                ))}
-                            </NavigationMenuList>
-                        </NavigationMenu>
-                    </div>
+            {/* Navigation */}
+            <NavigationMenu>
+              <NavigationMenuList className="flex gap-11 flex-nowrap">
+                {navigationItems.map((item) => (
+                  <NavigationMenuItem
+                    key={item.id}
+                    className="relative">
+                    <NavigationMenuLink
+                      href={`#${item.id}`}
+                      className="text-gray-5 font-bold text-[24px]">
+                      {item.label}
+                    </NavigationMenuLink>
+                  </NavigationMenuItem>
+                ))}
+              </NavigationMenuList>
+            </NavigationMenu>
+          </div>
 
-                    <div className="flex items-center gap-8">
-                        {/* Subscribe Button */}
-                        <div
-                            id="버튼 영역 추후 변경"
-                            className="w-[148px] h-[52px] bg-purple-1 rounded-lg text-white font-bold text-[24px] hover:bg-purple-2 flex items-center justify-center"
-                        >
-                            구독하기
-                        </div>
-
-                        {/* User Avatar */}
-                        <div className="p-1">
-                            <Image
-                                alt="avatar"
-                                src="/images/avatar.png"
-                                width={36}
-                                height={36}
-                                className="w-[36px] h-[36px] rounded-full object-cover"
-                            />
-                        </div>
-                    </div>
-                </div>
+          <div className="flex items-center gap-8">
+            {/* Subscribe Button */}
+            <div
+              id="버튼 영역 추후 변경"
+              className="w-[148px] h-[52px] bg-purple-1 rounded-lg text-white font-bold text-[24px] hover:bg-purple-2 flex items-center justify-center">
+              구독하기
             </div>
-        </header>
-    );
+
+            {/* User Avatar */}
+            <Link href="/mypage">
+              <div className="p-1">
+                <Image
+                  alt="avatar"
+                  src="/images/avatar.png"
+                  width={36}
+                  height={36}
+                  className="w-[36px] h-[36px] rounded-full object-cover"
+                />
+              </div>
+            </Link>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
 };
 
 export default Header;


### PR DESCRIPTION
## 🚀 PR 요약
- 마이페이지, 로딩페이지 퍼블리싱
- /mypage , /loading 
- 헤더에 아이콘 클릭시 마이페이지, 홈 이동 추가

## 📌 작업 내용

<!-- 어떤 작업을 했는지 자세히 설명해주세요
예시)
  - 다크 모드 토글 버튼 추가
  - 사용자의 테마 설정을 로컬 스토리지에 저장
-->

- 와이어프레임에 맞춰 단순 퍼블리싱

## 🔗 관련 이슈
  - #14 
  - #15 


-

## 📷 변경 전/후 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/d6bcc1ee-b1d9-45df-92ba-7f83a5a72745)
![image](https://github.com/user-attachments/assets/e405df59-0509-4752-a5b6-ab5c415ce70d)

<!-- UI 변경 사항이 있다면 스크린샷을 첨부해주세요 -->

## 📝 추가 정보 (선택)

<!-- PR과 관련하여 추가로 공유할 내용이 있다면 적어주세요
예시)
  - 배포 시 `.env` 설정 변경 필요
  - 관련 API 문서 업데이트 필요
-->
