### PR TITLE
[🎨 UI/UX] 뉴스 만들기 - 영상 만들기 화면 제작

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,17 @@
       "name": "unicat",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-aspect-ratio": "^1.1.2",
+        "@radix-ui/react-checkbox": "^1.1.4",
         "axios": "^1.8.2",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
         "cookies-next": "^5.1.0",
+        "lucide-react": "^0.483.0",
         "next": "15.0.4",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "tailwind-merge": "^3.0.2"
       },
       "devDependencies": {
         "@types/node": "^20.17.24",
@@ -815,6 +821,241 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
+      "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-aspect-ratio": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.2.tgz",
+      "integrity": "sha512-TaJxYoCpxJ7vfEkv2PTNox/6zzmpKXT6ewvCuf2tTOIVN45/Jahhlld29Yw4pciOXS2Xq91/rSGEdmEnUWZCqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.1.4.tgz",
+      "integrity": "sha512-wP0CPAHq+P5I4INKe3hJrIa1WoNqqrejzW+zoU0rOvo1b9gDEJJFl2rYfO1PYJUQCc2H1WZxIJmyv9BS8i5fLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
+      "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.2.tgz",
+      "integrity": "sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
+      "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
+      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+      "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+      "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+      "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz",
+      "integrity": "sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
+      "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -865,7 +1106,7 @@
       "version": "19.0.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
       "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -875,7 +1116,7 @@
       "version": "19.0.4",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.4.tgz",
       "integrity": "sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -1674,11 +1915,32 @@
         "node": ">= 6"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -1808,7 +2070,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -3902,6 +4164,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/lucide-react": {
+      "version": "0.483.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.483.0.tgz",
+      "integrity": "sha512-WldsY17Qb/T3VZdMnVQ9C3DDIP7h1ViDTHVdVGnLZcvHNg30zH/MTQ04RTORjexoGmpsXroiQXZ4QyR0kBy0FA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5530,6 +5801,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.0.2.tgz",
+      "integrity": "sha512-l7z+OYZ7mu3DTqrL88RiKrKIqO3NcpEO8V/Od04bNpvk0kiIFndGEoqfuzvj4yuhRkHKjRkII2z+KS2HfPcSxw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -10,11 +10,17 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-aspect-ratio": "^1.1.2",
+    "@radix-ui/react-checkbox": "^1.1.4",
     "axios": "^1.8.2",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "cookies-next": "^5.1.0",
+    "lucide-react": "^0.483.0",
     "next": "15.0.4",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "tailwind-merge": "^3.0.2"
   },
   "devDependencies": {
     "@types/node": "^20.17.24",

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -4,12 +4,12 @@ import Header from "@/src/components/layout/Header";
 
 export default function HomeLayout({ children }: { children: React.ReactNode }) {
     return (
-        <div className="bg-purple-6 min-h-screen flex flex-col">
+        <div className="min-h-screen flex flex-col">
             {/* 공통 헤더 */}
             <Header className="h-[100px]" />
 
             {/* 메인 콘텐츠 */}
-            <main className="flex-1 max-w-[1200px] mx-auto w-full mt-[105px]">
+            <main className="flex-1 bg-white max-w-[1200px] mx-auto w-full mt-[105px]">
                 {children}
             </main>
 

--- a/src/app/(home)/news-making/(movie-style)/page.tsx
+++ b/src/app/(home)/news-making/(movie-style)/page.tsx
@@ -19,7 +19,7 @@ export default function AiNews() {
 
     return (
 
-        <div className="flex flex-col items-center min-h-screen mt-[205px] gap-[40px]">
+        <div className="flex flex-col items-center min-h-screen gap-[40px]">
           {/* 헤더 */}
           <header className="flex w-full items-center justify-between">
             <div className="flex items-center gap-4">

--- a/src/app/(home)/news-making/(movie-style)/page.tsx
+++ b/src/app/(home)/news-making/(movie-style)/page.tsx
@@ -57,6 +57,8 @@ export default function AiNews() {
                         altText={style.alt}
                         onClick={() => setSelectedStyle(style.id)} // ✅ 클릭 시 상태 변경
                         isSelected={selectedStyle === style.id} // ✅ 선택된 경우 스타일 변경
+                        width={268}
+                        height={300}
                     />
                 ))}
             </div>

--- a/src/app/(home)/news-making/(movie-style)/page.tsx
+++ b/src/app/(home)/news-making/(movie-style)/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/src/components/common/Button";
 import ArtStyleCard from "@/src/components/news-making/card/ArtStyleCard";
 import StepIndicator from "@/src/components/news-making/StepIndicator";
 import Image from "next/image";
+import Link from "next/link";
 
 const artStyles = [
     { id: 1, imageSrc: "/images/news-making/news-style-1.png", alt: "스타일 1" },
@@ -64,8 +65,9 @@ export default function AiNews() {
             </div>
 
             {/* ✅ 선택된 경우 `NextButton` 스타일 변경 */}
-            {/* 버튼 컨테이너 */}
+            {/* 다음으로 버튼 컨테이너 */}
             <div className="w-full flex justify-end">
+              <Link href="/news-making/thumbnail">
                 <Button
                     className={`w-[268px] h-[80px] rounded-[15px] text-white font-bold text-[24px] transition-colors 
                         ${selectedStyle !== null ? "bg-purple-1" : "bg-gray-2"}`}
@@ -80,7 +82,7 @@ export default function AiNews() {
                 >
                     다음으로
                 </Button>
-
+              </Link>
             </div>
 
         </div>

--- a/src/app/(home)/news-making/create/page.tsx
+++ b/src/app/(home)/news-making/create/page.tsx
@@ -73,7 +73,7 @@ export default function Element () {
 										title={"기본 제목"}
 										imageSrc={""} // 공백일 경우 더미 이미지
 										altText={"썸네일 카드"}
-										className="w-full h-auto object-contain"
+										/*className="w-full h-auto object-contain"*/
 									/>
 								</div>
 							</CardContent>

--- a/src/app/(home)/news-making/create/page.tsx
+++ b/src/app/(home)/news-making/create/page.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+// Lucide 아이콘 라이브러리에서 아이콘을 가져옴
+import { PlusIcon, XIcon } from "lucide-react";
+import React from "react";
+import { Button } from "@/src/components/news-making/button/CreateCommonButton";
+import { Card, CardContent } from "@/src/components/news-making/card/CreateCard";
+import { Checkbox } from "@/src/components/news-making/CreateCheckbox";
+import ArtStyleCard from "@/src/components/news-making/card/ArtStyleCard";
+import ThumbnailCard from "@/src/components/news-making/card/ThumbnailCard";
+import VoiceDropdown from "@/src/components/news-making/VoiceDropdown";
+
+const artStyles = [
+	{ id: 1, imageSrc: "/images/news-making/news-style-1.png", alt: "스타일 1" },
+	{ id: 2, imageSrc: "/images/news-making/news-style-2.png", alt: "스타일 2" },
+	{ id: 3, imageSrc: "/images/news-making/news-style-3.png", alt: "스타일 3" },
+	{ id: 4, imageSrc: "/images/news-making/news-style-4.png", alt: "스타일 4" },
+];
+
+// ✅ 아무거나 하나 선택 (예: 첫 번째 스타일 사용)
+const selectedStyle = artStyles[0]; // 혹은 다른 인덱스로 변경 가능
+
+export default function Element () {
+
+	const contentSections = [
+		{ title: "내레이션", buttonText: "LLM 수정 버튼", hasCheckbox: true },
+		{ title: "텍스트를 입력하세요", buttonText: "LLM 수정 버튼", hasCheckbox: true },
+	];
+
+	return (
+		<div className="bg-white flex flex-row justify-center w-full">
+			<div className="bg-white w-full max-w-[1920px] p-6 relative">
+				<div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+					{/* 왼쪽 컬럼: 비디오 스타일 & 썸네일 */}
+					<div className="md:col-span-1 space-y-6 overflow-hidden">
+						{/* 왼쪽 영역 상단: ArtStyleCard 적용 */}
+						<Card className="overflow-hidden border rounded-lg shadow-sm h-auto"> {/* ✅ 여기 추가 */}
+							<CardContent className="flex flex-col justify-center items-center h-auto">
+								<h3 className="text-3xl font-bold font-bold-32 mb-3 p-3 mt-3">
+									{"영상 스타일"}
+								</h3>
+								<div className="rounded-md">
+									<ArtStyleCard
+										imageSrc={selectedStyle.imageSrc}
+										altText={selectedStyle.alt}
+										isSelected={true}
+										onClick={() => {}}
+										className="mx-auto"
+										width={200}
+										height={224}
+										applyBorderBox={true}
+									/>
+								</div>
+							</CardContent>
+						</Card>
+						<div className="md:col-span-1 space-y-6 overflow-hidden">
+						</div>
+						{/* 왼쪽 영역 하단: Thumbnail Card 적용 */}
+						<Card className="overflow-hidden border rounded-lg shadow-sm h-auto">
+							<CardContent className="flex flex-col justify-center items-center h-auto">
+								{/* 카드 제목 */}
+								<h3 className="text-3xl font-bold font-bold-32 mb-3 p-3 mt-3">
+									{"영상 썸네일"}
+								</h3>
+
+								{/* 썸네일 카드 컨테이너 */}
+								<div className="flex items-center justify-center w-full h-auto">
+									<ThumbnailCard
+										key={"1"}
+										artStyleId={1}
+										thumbnailId={1}
+										title={"기본 제목"}
+										imageSrc={""} // 공백일 경우 더미 이미지
+										altText={"썸네일 카드"}
+										className="w-full h-auto object-contain"
+									/>
+								</div>
+							</CardContent>
+						</Card>
+
+					</div>
+
+					{/* 오른쪽 컬럼: 콘텐츠 카드들 컷 단위 추가 */}
+					<div className="md:col-span-3 space-y-6">
+						{contentSections.map((section, index) => (
+							<Card key={index} className="border rounded-lg shadow-sm">
+								<CardContent className="p-0">
+									<div className="flex items-start">
+										{section.hasCheckbox && (
+											<div className="p-4">
+												<Checkbox id={`section-${index}`} />
+											</div>
+										)}
+										<div className="flex-1 p-4">
+											<div className="flex justify-between items-center mb-4">
+												<h3 className="text-sm text-slate-500">
+													{section.title}
+												</h3>
+												<Button variant="ghost" size="icon" className="h-6 w-6">
+													<XIcon className="h-4 w-4" />
+												</Button>
+											</div>
+											<div className="aspect-video bg-slate-50 rounded-md border border-slate-200 mb-4"></div>
+											<div className="flex justify-end">
+												<Button variant="outline" size="sm" className="text-xs">
+													{section.buttonText}
+												</Button>
+											</div>
+										</div>
+									</div>
+								</CardContent>
+							</Card>
+						))}
+					</div>
+				</div>
+
+				{/* 하단 컨트롤 버튼 */}
+				<div className="flex justify-between mt-6">
+					<Button variant="outline" size="sm" className="flex items-center gap-1">
+						<VoiceDropdown/>
+					</Button>
+					<Button variant="outline" size="sm" className="flex items-center gap-1">
+						<PlusIcon className="h-4 w-4" />
+						<span>콘텐츠 추가</span>
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/src/app/(home)/news-making/create/page.tsx
+++ b/src/app/(home)/news-making/create/page.tsx
@@ -3,12 +3,13 @@
 // Lucide 아이콘 라이브러리에서 아이콘을 가져옴
 import { PlusIcon, XIcon } from "lucide-react";
 import React from "react";
-import { Button } from "@/src/components/news-making/button/CreateCommonButton";
+import { Button } from "@/src/components/news-making/button/CommonNewsMakingButton";
 import { Card, CardContent } from "@/src/components/news-making/card/CreateCard";
 import { Checkbox } from "@/src/components/news-making/CreateCheckbox";
 import ArtStyleCard from "@/src/components/news-making/card/ArtStyleCard";
 import ThumbnailCard from "@/src/components/news-making/card/ThumbnailCard";
 import VoiceDropdown from "@/src/components/news-making/VoiceDropdown";
+import Link from "next/link";
 
 const artStyles = [
 	{ id: 1, imageSrc: "/images/news-making/news-style-1.png", alt: "스타일 1" },
@@ -23,19 +24,19 @@ const selectedStyle = artStyles[0]; // 혹은 다른 인덱스로 변경 가능
 export default function Element () {
 
 	const contentSections = [
-		{ title: "내레이션", buttonText: "LLM 수정 버튼", hasCheckbox: true },
-		{ title: "텍스트를 입력하세요", buttonText: "LLM 수정 버튼", hasCheckbox: true },
+		{ title: "썸네일", buttonText: "LLM 수정 버튼", hasCheckbox: true },
+		{ title: "컷 1", buttonText: "LLM 수정 버튼", hasCheckbox: true },
 	];
 
 	return (
-		<div className="bg-white flex flex-row justify-center w-full">
-			<div className="bg-white w-full max-w-[1920px] p-6 relative">
+		<div className="bg-purple-6 flex flex-row justify-center w-full border-b-[30px] border-white">
+			<div className="bg-purple-6 w-full max-w-[1920px] p-12 pl-6 pt-6 pr-6 relative">
 				<div className="grid grid-cols-1 md:grid-cols-4 gap-6">
 					{/* 왼쪽 컬럼: 비디오 스타일 & 썸네일 */}
 					<div className="md:col-span-1 space-y-6 overflow-hidden">
 						{/* 왼쪽 영역 상단: ArtStyleCard 적용 */}
 						<Card className="overflow-hidden border rounded-lg shadow-sm h-auto"> {/* ✅ 여기 추가 */}
-							<CardContent className="flex flex-col justify-center items-center h-auto">
+							<CardContent className="bg-white flex flex-col justify-center items-center h-auto">
 								<h3 className="text-3xl font-bold font-bold-32 mb-3 p-3 mt-3">
 									{"영상 스타일"}
 								</h3>
@@ -79,7 +80,6 @@ export default function Element () {
 						</Card>
 
 					</div>
-
 					{/* 오른쪽 컬럼: 콘텐츠 카드들 컷 단위 추가 */}
 					<div className="md:col-span-3 space-y-6">
 						{contentSections.map((section, index) => (
@@ -92,37 +92,59 @@ export default function Element () {
 											</div>
 										)}
 										<div className="flex-1 p-4">
-											<div className="flex justify-between items-center mb-4">
-												<h3 className="text-sm text-slate-500">
-													{section.title}
-												</h3>
+											{/* 썸네일 X버튼 컷씬 X버튼 이미지 및 스크립트 영역 */ }
+											{/* 제목 & 닫기 버튼을 한 줄에 정렬 */}
+											<div className="flex justify-between items-start mb-2">
+												<h3 className="text-sm text-slate-500">{section.title}</h3>
 												<Button variant="ghost" size="icon" className="h-6 w-6">
 													<XIcon className="h-4 w-4" />
 												</Button>
 											</div>
-											<div className="aspect-video bg-slate-50 rounded-md border border-slate-200 mb-4"></div>
-											<div className="flex justify-end">
-												<Button variant="outline" size="sm" className="text-xs">
+
+											{/* 카드 내용 이미지 및 스크립트 영역 */}
+											<div className="flex w-full max-w-[773px] h-[300px] border rounded-lg shadow-sm overflow-hidden">
+												<div className="w-1/3 bg-gray-200 flex items-center justify-center">
+													<span className="text-gray-500">이미지 삽입</span>
+												</div>
+												<div className="w-2/3 bg-white p-4 flex flex-col justify-between">
+												<textarea
+													className="w-full h-full p-2 resize-none focus:outline-none"
+													placeholder="텍스트를 입력하세요..."
+												/>
+												{/* 카드 컨텐츠 별 버튼 텍스트 LLM 수정버튼 */}
+												<Button variant="outline" size="sm" className="w-[120px] h-[40px]">
 													{section.buttonText}
 												</Button>
+												</div>
 											</div>
 										</div>
 									</div>
 								</CardContent>
 							</Card>
 						))}
-					</div>
-				</div>
+						{/* //content section */}
+						{/* 하단 컨트롤 버튼 */}
+						<div className="flex justify-between mt-6">
+							<VoiceDropdown/>
+							<Button variant="outline" size="sm" className="ml-2 p-0 w-full flex items-center gap-1">
+								<PlusIcon className="h-4 w-4" />
+								<span>콘텐츠 추가</span>
+							</Button>
+						</div>
+						<div className="w-full max-w-[1200px] flex justify-end gap-6">
+							<Link href="/news-making/thumbnail">
+								<Button variant="preview" className="w-[200px] h-[60px]">
+									이전으로
+								</Button>
+							</Link>
 
-				{/* 하단 컨트롤 버튼 */}
-				<div className="flex justify-between mt-6">
-					<Button variant="outline" size="sm" className="flex items-center gap-1">
-						<VoiceDropdown/>
-					</Button>
-					<Button variant="outline" size="sm" className="flex items-center gap-1">
-						<PlusIcon className="h-4 w-4" />
-						<span>콘텐츠 추가</span>
-					</Button>
+							<Link href="/loading">
+								<Button variant="next" className="w-[200px] h-[60px]">
+									다음으로
+								</Button>
+							</Link>
+						</div>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/src/app/(home)/news-making/thumbnail/page.tsx
+++ b/src/app/(home)/news-making/thumbnail/page.tsx
@@ -38,7 +38,8 @@ export default function AiNewsAnima() {
 
 	const [projectCards, setProjectCards] = useState<ProjectCard[]>(initialProjectCards);
 
-	const updateCard = (id: number, key: keyof ProjectCard, value: any) => {
+	// ProjectCart에 맞게 key, value 선언
+	const updateCard = <K extends keyof ProjectCard>(id: number, key: K, value: ProjectCard[K]) => {
 		setProjectCards((prev) =>
 			prev.map((card) => (card.id === id ? { ...card, [key]: value } : card))
 		);

--- a/src/app/(home)/news-making/thumbnail/page.tsx
+++ b/src/app/(home)/news-making/thumbnail/page.tsx
@@ -6,17 +6,58 @@ import PreviewButton from "@/src/components/news-making/button/PreviewButton";
 import ThumbnailCard from "@/src/components/news-making/card/ThumbnailCard";
 import ImageMakingButton from "@/src/components/news-making/button/ImageMakingButton";
 import ThumbnailImageModal from "@/src/components/news-making/ThumbnailImageModal";
+import ThumbnailFontMenu from "@/src/components/news-making/ThumbnailFontMenu";
 
-const projectCards = [
-	{ id: 1, artStyleId: 1, thumbnailId: 101, imageSrc: "", altText: "스타일 1" },
-	{ id: 2, artStyleId: 2, thumbnailId: 102, imageSrc: "", altText: "스타일 2" },
-	{ id: 3, artStyleId: 3, thumbnailId: 103, imageSrc: "", altText: "스타일 3" },
-	{ id: 4, artStyleId: 4, thumbnailId: 104, imageSrc: "", altText: "스타일 4" },
+interface ProjectCard {
+	id: number;
+	artStyleId: number;
+	thumbnailId: number;
+	imageSrc: string;
+	altText: string;
+	textAlign: "left" | "center" | "right";
+	fontColor: string;
+	fontSize: number;
+	fontFamily: "Arial" | "Times New Roman" | "Courier New" | "Verdana";
+}
+
+const initialProjectCards: ProjectCard[] = [
+	{ id: 1, artStyleId: 1, thumbnailId: 101, imageSrc: "", altText: "스타일 1", textAlign: "left", fontColor: "#ff5733", fontSize: 20, fontFamily: "Arial" },
+	{ id: 2, artStyleId: 2, thumbnailId: 102, imageSrc: "", altText: "스타일 2", textAlign: "center", fontColor: "#33ff57", fontSize: 24, fontFamily: "Times New Roman" },
+	{ id: 3, artStyleId: 3, thumbnailId: 103, imageSrc: "", altText: "스타일 3", textAlign: "right", fontColor: "#3357ff", fontSize: 18, fontFamily: "Courier New" },
+	{ id: 4, artStyleId: 4, thumbnailId: 104, imageSrc: "", altText: "스타일 4", textAlign: "center", fontColor: "#ff33a1", fontSize: 22, fontFamily: "Verdana" }
 ];
+
+// ✅ 가장 작은 폰트 크기 기준으로 `maxLines` 계산
+const minFontSize = Math.min(...initialProjectCards.map((card) => card.fontSize));
+const lineHeight = minFontSize * 1.2;
+const maxTextareaHeight = 108;
+const maxLines = Math.floor(maxTextareaHeight / lineHeight);
 
 export default function AiNewsAnima() {
 	const [title, setTitle] = useState<string>("");
-	const [isModalOpen, setIsModalOpen] = useState(false); // ✅ 모달 상태 추가
+
+	const [projectCards, setProjectCards] = useState<ProjectCard[]>(initialProjectCards);
+
+	const updateCard = (id: number, key: keyof ProjectCard, value: any) => {
+		setProjectCards((prev) =>
+			prev.map((card) => (card.id === id ? { ...card, [key]: value } : card))
+		);
+	};
+
+	const [isModalOpen, setIsModalOpen] = useState(false);
+
+	const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+		const inputValue = e.target.value;
+
+		// ✅ 최대 줄 수 제한 (가장 작은 폰트 기준)
+		const lines = inputValue.split("\n").slice(0, maxLines);
+
+		// ✅ 한 줄당 최대 14자 제한
+		const limitedLines = lines.map((line) => line.slice(0, 14));
+
+		setTitle(limitedLines.join("\n"));
+	};
+
 	return (
 		<div className="flex flex-col items-center min-h-screen gap-[40px] bg-purple-6">
 			{/* 헤더 */}
@@ -31,48 +72,48 @@ export default function AiNewsAnima() {
 			{/* 프로젝트 카드 리스트 */}
 			<div className="grid grid-cols-4 gap-10 w-full max-w-[1200px]">
 				{projectCards.map((card) => (
-					<ThumbnailCard
-						key={card.thumbnailId}
-						artStyleId={card.artStyleId}
-						thumbnailId={card.thumbnailId}
-						title={title || "기본 제목"} // ✅ 입력된 제목을 모든 카드에 반영
-						imageSrc={card.imageSrc}
-						altText={card.altText}
-					/>
+					<div key={card.thumbnailId} className="flex flex-col items-center">
+						<ThumbnailCard
+							artStyleId={card.artStyleId}
+							thumbnailId={card.thumbnailId}
+							title={title}
+							imageSrc={card.imageSrc}
+							altText={card.altText}
+							textAlign={card.textAlign}
+							fontColor={card.fontColor}
+							fontSize={card.fontSize}
+							fontFamily={card.fontFamily}
+						/>
+						{/* ✅ 폰트 설정 UI (컴포넌트 분리) */}
+						<ThumbnailFontMenu
+							fontSize={card.fontSize}
+							fontFamily={card.fontFamily}
+							fontColor={card.fontColor}
+							textAlign={card.textAlign}
+							onUpdate={(key, value) => updateCard(card.id, key as keyof ProjectCard, value)}
+						/>
+					</div>
 				))}
 			</div>
 
-			{/* 제목 입력 필드 */}
-			<div className="w-full max-w-[1200px] h-[120px] flex items-center border border-gray-300 bg-white rounded-lg px-4">
-				<textarea
+			{/* ✅ 제목 입력 필드 */}
+			<div className="relative w-full max-w-[1200px] h-[120px] flex items-center border border-gray-300 bg-white rounded-lg px-4">
+        <textarea
 					className="w-full h-full border-none text-center focus:ring-0 focus:outline-none text-gray-700 text-lg resize-none"
 					placeholder="영상에서 사용할 제목을 적어주세요."
 					value={title}
-					onChange={(e) => {
-						// 현재 입력값
-						const inputValue = e.target.value;
-
-						// 줄 단위로 분리
-						const lines = inputValue.split("\n");
-
-						// ✅ 각 줄의 최대 길이를 14자로 제한
-						const limitedLines = lines.map((line) => line.slice(0, 14));
-
-						// ✅ 최대 3줄까지만 입력 가능
-						if (limitedLines.length > 3) return;
-
-						// 상태 업데이트
-						setTitle(limitedLines.join("\n"));
-					}}
-					rows={3} // ✅ 기본 3줄 입력 가능
+					onChange={handleInputChange}
+					rows={maxLines}
 				/>
 			</div>
+
 			{/* 버튼 영역 */}
-			<ImageMakingButton onClick={() => setIsModalOpen(true)}></ImageMakingButton>
+			<ImageMakingButton onClick={() => setIsModalOpen(true)} />
 			<div className="w-full max-w-[1200px] flex justify-end gap-6">
-				<PreviewButton className="w-[290px] h-[80px]"></PreviewButton>
-				<NextButton className="w-[290px] h-[80px]"></NextButton>
+				<PreviewButton className="w-[290px] h-[80px]" />
+				<NextButton className="w-[290px] h-[80px]" />
 			</div>
+
 			{/* 모달 */}
 			<ThumbnailImageModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />
 		</div>

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -17,3 +17,4 @@ export const Button = ({ children, className, onClick }: ButtonProps) => {
         </button>
     );
 };
+

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -23,7 +23,7 @@ const navigationItems = [
 const Header: React.FC<HeaderProps> = ({ className }) => {
   return (
     <header className={`flex flex-col items-center w-full border-b border-[#ECECEC] ${className}`}>
-      <div className="w-full h-[100px] bg-basewhite border-b border-[#ECECEC]">
+      <div className="w-full h-[100px] bg-white border-b border-[#ECECEC]">
         <div className="container flex items-center justify-between h-full max-w-[1200px] mx-auto px-4">
           <div className="flex items-center gap-11">
             {/* Logo */}

--- a/src/components/news-making/CreateCheckbox.tsx
+++ b/src/components/news-making/CreateCheckbox.tsx
@@ -1,0 +1,25 @@
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { CheckIcon } from "lucide-react";
+import * as React from "react";
+import { cn } from "@/src/utils/cn";
+
+const Checkbox = React.forwardRef<
+	React.ElementRef<typeof CheckboxPrimitive.Root>,
+	React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+	<CheckboxPrimitive.Root
+		ref={ref}
+		className={cn(
+			"peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+			className,
+		)}
+		{...props}
+	>
+		<CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
+			<CheckIcon className="h-4 w-4" />
+		</CheckboxPrimitive.Indicator>
+	</CheckboxPrimitive.Root>
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };

--- a/src/components/news-making/ThumbnailFontMenu.tsx
+++ b/src/components/news-making/ThumbnailFontMenu.tsx
@@ -5,7 +5,7 @@ interface ThumbnailFontMenuProps {
 	fontFamily: string;
 	fontColor: string;
 	textAlign: "left" | "center" | "right";
-	onUpdate: (key: string, value: any) => void;
+	onUpdate: (key: string, value: number | string) => void;
 }
 
 const ThumbnailFontMenu: React.FC<ThumbnailFontMenuProps> = ({ fontSize, fontFamily, fontColor, textAlign, onUpdate }) => {

--- a/src/components/news-making/ThumbnailFontMenu.tsx
+++ b/src/components/news-making/ThumbnailFontMenu.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from "react";
+
+interface ThumbnailFontMenuProps {
+	fontSize: number;
+	fontFamily: string;
+	fontColor: string;
+	textAlign: "left" | "center" | "right";
+	onUpdate: (key: string, value: any) => void;
+}
+
+const ThumbnailFontMenu: React.FC<ThumbnailFontMenuProps> = ({ fontSize, fontFamily, fontColor, textAlign, onUpdate }) => {
+	const [customFontSize, setCustomFontSize] = useState(fontSize);
+
+	// ✅ 입력 값이 숫자인지 확인 & 범위 제한 적용 (12 ~ 40)
+	const handleFontSizeChange = (value: string) => {
+		let newSize = Number(value);
+		if (isNaN(newSize)) return;
+		if (newSize < 12) newSize = 12;
+		if (newSize > 40) newSize = 40;
+		setCustomFontSize(newSize);
+		onUpdate("fontSize", newSize);
+	};
+
+	return (
+		<div className="flex flex-col gap-2 w-[250px] p-3 bg-gray-100 rounded-lg shadow">
+			{/* 🔹 폰트 크기 선택 (드롭다운 + 직접 입력) */}
+			<label className="text-sm font-semibold">폰트 크기</label>
+			<div className="flex gap-2 items-center">
+				<select
+					className="border p-1 rounded w-20"
+					value={customFontSize}
+					onChange={(e) => handleFontSizeChange(e.target.value)}
+				>
+					{[12, 14, 16, 18, 20, 24, 28, 32, 36, 40].map((size) => (
+						<option key={size} value={size}>
+							{size}
+						</option>
+					))}
+				</select>
+				<input
+					type="text"
+					className="border px-2 py-1 w-14 text-center rounded"
+					value={customFontSize}
+					onChange={(e) => handleFontSizeChange(e.target.value)}
+				/>
+			</div>
+
+			{/* 🔹 폰트 종류 선택 */}
+			<label className="text-sm font-semibold">폰트</label>
+			<select
+				className="border p-1 rounded"
+				value={fontFamily}
+				onChange={(e) => onUpdate("fontFamily", e.target.value)}
+			>
+				<option value="Arial">Arial</option>
+				<option value="Times New Roman">Times New Roman</option>
+				<option value="Courier New">Courier New</option>
+				<option value="Verdana">Verdana</option>
+			</select>
+
+			{/* 🔹 색상 선택 */}
+			<label className="text-sm font-semibold">색상</label>
+			<input
+				type="color"
+				value={fontColor}
+				onChange={(e) => onUpdate("fontColor", e.target.value)}
+			/>
+
+			{/* 🔹 정렬 선택 */}
+			<label className="text-sm font-semibold">정렬</label>
+			<div className="flex gap-2">
+				{["left", "center", "right"].map((align) => (
+					<button
+						key={align}
+						onClick={() => onUpdate("textAlign", align)}
+						className={`px-3 py-1 rounded ${
+							textAlign === align ? "bg-blue-500 text-white" : "bg-gray-300"
+						}`}
+					>
+						{align.toUpperCase()}
+					</button>
+				))}
+			</div>
+		</div>
+	);
+};
+
+export default ThumbnailFontMenu;

--- a/src/components/news-making/ThumbnailImageModal.tsx
+++ b/src/components/news-making/ThumbnailImageModal.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import React from "react";
 import ModalImageUploadSelfButton from "@/src/components/news-making/button/ModalImageUploadSelfButton";
 import ModalImageUploadAiButton from "@/src/components/news-making/button/ModalImageUploadAiButton";
+import Link from "next/link";
 
 interface ThumbnailImageModalProps {
 	isOpen: boolean;
@@ -20,7 +23,9 @@ export default function ThumbnailImageModal({ isOpen, onClose }: ThumbnailImageM
 				<h2 className="font-bold font-bold-24 text-2xl">이미지 업로드</h2>
 					<p className="text-gray-500">이미지를 업로드하세요.</p>
 					<ModalImageUploadSelfButton></ModalImageUploadSelfButton>
+				<Link href="/news-making/create">
 					<ModalImageUploadAiButton></ModalImageUploadAiButton>
+				</Link>
 					{/* ✅ 닫기 버튼 */}
 					<button className="mt-4 px-4 py-2 bg-gray-300 rounded" onClick={onClose}>
 						닫기

--- a/src/components/news-making/VoiceDropdown.tsx
+++ b/src/components/news-making/VoiceDropdown.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { ChevronDownIcon } from "lucide-react";
-import { Button } from "@/src/components/news-making/button/CreateCommonButton";
+import { Button } from "@/src/components/news-making/button/CommonNewsMakingButton";
 
 export default function VoiceDropdown() {
 	const [isOpen, setIsOpen] = useState(false);

--- a/src/components/news-making/VoiceDropdown.tsx
+++ b/src/components/news-making/VoiceDropdown.tsx
@@ -17,16 +17,16 @@ export default function VoiceDropdown() {
 			<Button
 				variant="outline"
 				size="sm"
-				className="flex items-center gap-1"
+				className="flex items-center gap-1 min-w-[110px]" // ✅ 최소 너비 110px 설정
 				onClick={toggleDropdown}
 			>
 				<ChevronDownIcon className="h-4 w-4" />
-				<span>{selectedVoice}</span>
+				<span className="truncate">{selectedVoice}</span> {/* 너무 길면 ... 처리 */}
 			</Button>
 
 			{isOpen && (
 				<div className="absolute left-0 mt-2 w-40 bg-white border rounded-md shadow-lg z-10">
-					<ul className="py-2 text-sm text-gray-700">
+					<ul className="py-2 text-sm text-gray-700 w-full h-32 overflow-auto">
 						{["10대 목소리", "20대 목소리", "30대 목소리"].map((voice) => (
 							<li
 								key={voice}
@@ -39,6 +39,7 @@ export default function VoiceDropdown() {
 					</ul>
 				</div>
 			)}
+
 		</div>
 	);
 }

--- a/src/components/news-making/VoiceDropdown.tsx
+++ b/src/components/news-making/VoiceDropdown.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { ChevronDownIcon } from "lucide-react";
+import { Button } from "@/src/components/news-making/button/CreateCommonButton";
+
+export default function VoiceDropdown() {
+	const [isOpen, setIsOpen] = useState(false);
+	const [selectedVoice, setSelectedVoice] = useState("10대 목소리");
+
+	const toggleDropdown = () => setIsOpen(!isOpen);
+	const handleSelect = (voice: string) => {
+		setSelectedVoice(voice);
+		setIsOpen(false);
+	};
+
+	return (
+		<div className="relative inline-block">
+			<Button
+				variant="outline"
+				size="sm"
+				className="flex items-center gap-1"
+				onClick={toggleDropdown}
+			>
+				<ChevronDownIcon className="h-4 w-4" />
+				<span>{selectedVoice}</span>
+			</Button>
+
+			{isOpen && (
+				<div className="absolute left-0 mt-2 w-40 bg-white border rounded-md shadow-lg z-10">
+					<ul className="py-2 text-sm text-gray-700">
+						{["10대 목소리", "20대 목소리", "30대 목소리"].map((voice) => (
+							<li
+								key={voice}
+								className="px-4 py-2 hover:bg-gray-100 cursor-pointer"
+								onClick={() => handleSelect(voice)}
+							>
+								{voice}
+							</li>
+						))}
+					</ul>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/components/news-making/button/CommonNewsMakingButton.tsx
+++ b/src/components/news-making/button/CommonNewsMakingButton.tsx
@@ -3,22 +3,19 @@ import { type VariantProps, cva } from "class-variance-authority";
 import * as React from "react";
 import { cn } from "@/src/utils/cn";
 
-
 const buttonVariants = cva(
 	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
 	{
 		variants: {
 			variant: {
-				default:
-					"bg-primary text-primary-foreground shadow hover:bg-primary/90",
-				destructive:
-					"bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
-				outline:
-					"border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
-				secondary:
-					"bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+				default: "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+				destructive: "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+				outline: "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+				secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
 				ghost: "hover:bg-accent hover:text-accent-foreground",
 				link: "text-primary underline-offset-4 hover:underline",
+				next: "w-[268px] h-[80px] bg-gray-2 rounded-[15px] text-white font-bold text-[24px] hover:bg-purple-1 transition-colors",
+				preview: "w-[268px] h-[80px] bg-white border-2 border-purple-1 rounded-[15px] text-purple-1 font-bold text-[24px] hover:bg-purple-100 transition-colors",
 			},
 			size: {
 				default: "h-9 px-4 py-2",
@@ -31,18 +28,20 @@ const buttonVariants = cva(
 			variant: "default",
 			size: "default",
 		},
-	},
+	}
 );
 
 export interface ButtonProps
 	extends React.ButtonHTMLAttributes<HTMLButtonElement>,
 		VariantProps<typeof buttonVariants> {
 	asChild?: boolean;
+	className?: string;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 	({ className, variant, size, asChild = false, ...props }, ref) => {
 		const Comp = asChild ? Slot : "button";
+
 		return (
 			<Comp
 				className={cn(buttonVariants({ variant, size, className }))}
@@ -50,7 +49,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 				{...props}
 			/>
 		);
-	},
+	}
 );
 Button.displayName = "Button";
 

--- a/src/components/news-making/button/CreateCommonButton.tsx
+++ b/src/components/news-making/button/CreateCommonButton.tsx
@@ -1,0 +1,57 @@
+import { Slot } from "@radix-ui/react-slot";
+import { type VariantProps, cva } from "class-variance-authority";
+import * as React from "react";
+import { cn } from "@/src/utils/cn";
+
+
+const buttonVariants = cva(
+	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+	{
+		variants: {
+			variant: {
+				default:
+					"bg-primary text-primary-foreground shadow hover:bg-primary/90",
+				destructive:
+					"bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+				outline:
+					"border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+				secondary:
+					"bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+				ghost: "hover:bg-accent hover:text-accent-foreground",
+				link: "text-primary underline-offset-4 hover:underline",
+			},
+			size: {
+				default: "h-9 px-4 py-2",
+				sm: "h-8 rounded-md px-3 text-xs",
+				lg: "h-10 rounded-md px-8",
+				icon: "h-9 w-9",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+			size: "default",
+		},
+	},
+);
+
+export interface ButtonProps
+	extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+		VariantProps<typeof buttonVariants> {
+	asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+	({ className, variant, size, asChild = false, ...props }, ref) => {
+		const Comp = asChild ? Slot : "button";
+		return (
+			<Comp
+				className={cn(buttonVariants({ variant, size, className }))}
+				ref={ref}
+				{...props}
+			/>
+		);
+	},
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/src/components/news-making/card/ArtStyleCard.tsx
+++ b/src/components/news-making/card/ArtStyleCard.tsx
@@ -1,27 +1,56 @@
 import Image from "next/image";
+import { cn } from "@/src/utils/cn"; // ✅ cn 함수 가져오기
 
 interface ArtStyleCardProps {
-    imageSrc: string;
-    altText: string;
-    onClick: () => void;
-    isSelected: boolean;
+  imageSrc: string;
+  altText: string;
+  onClick?: () => void;
+  isSelected: boolean;
+  width?: number;
+  height?: number;
+  className?: string;
 }
 
-export default function ArtStyleCard({ imageSrc, altText, onClick, isSelected }: ArtStyleCardProps) {
-    return (
-        <div
-            className={`w-[268px] h-[300px] overflow-hidden cursor-pointer rounded-2xl 
-                        transition-all border ${isSelected ? "border-[10px] border-purple-500 shadow-lg" : "border border-gray-300"}`}
-            onClick={onClick}
-        >
-            <Image
-                src={imageSrc}
-                alt={altText}
-                width={268}
-                height={300}
-                className="w-full h-full object-cover rounded"
-            />
-        </div>
-    );
+// 기본 width, height 268 300 이전 Props로 속성 전달시 변경됨
+interface ArtStyleCardProps {
+  imageSrc: string;
+  altText: string;
+  onClick?: () => void;
+  isSelected: boolean;
+  applyBorderBox?: boolean; // ✅ 특정 컴포넌트에서만 적용할 수 있는 새로운 prop
+  width?: number;
+  height?: number;
+  className?: string;
 }
 
+export default function ArtStyleCard({
+                                       imageSrc,
+                                       altText,
+                                       onClick,
+                                       isSelected,
+                                       applyBorderBox = false, // ✅ 기본값 false (기존 동작 유지)
+                                       width = 268,
+                                       height = 300,
+                                       className,
+                                     }: ArtStyleCardProps) {
+  return (
+    <div
+      className={cn(
+        "relative overflow-hidden cursor-pointer rounded-2xl transition-all",
+        isSelected ? "border-[10px] border-purple-500 shadow-lg" : "border border-gray-300",
+        applyBorderBox ? "box-border" : "", // ✅ createPage에서 보더 테두리가 존재하는 이미지로 사용하기 위해 추가
+        `w-[${width}px] h-[${height}px]`,
+        className
+      )}
+      onClick={onClick}
+    >
+      <Image
+        src={imageSrc}
+        alt={altText}
+        width={width} // ✅ width 적용
+        height={height} // ✅ height 적용
+        className="w-full h-full object-cover rounded"
+      />
+    </div>
+  );
+}

--- a/src/components/news-making/card/CreateCard.tsx
+++ b/src/components/news-making/card/CreateCard.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import { cn } from "@/src/utils/cn";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+	({ className, ...props }, ref) => (
+		<div ref={ref} className={cn("rounded-xl border bg-card text-card-foreground shadow", className)} {...props} />
+	)
+);
+Card.displayName = "Card";
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+	({ className, ...props }, ref) => (
+		<div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+	)
+);
+CardContent.displayName = "CardContent";
+
+export { Card, CardContent };

--- a/src/components/news-making/card/ThumbnailCard.tsx
+++ b/src/components/news-making/card/ThumbnailCard.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import React from "react";
+import { cn } from "@/src/utils/cn"; // ✅ cn 함수 가져오기
 
 interface ThumbnailCardProps {
 	artStyleId: number;
@@ -9,32 +10,33 @@ interface ThumbnailCardProps {
 	altText: string;
 	onClick?: () => void;
 	isSelected?: boolean;
+	className?: string;
 }
 
 export default function ThumbnailCard(props: ThumbnailCardProps) {
-	const { thumbnailId, artStyleId, title, imageSrc, altText, onClick, isSelected } = props;
+	const { thumbnailId, artStyleId, title, imageSrc, altText, onClick, isSelected, className } = props;
 
 	return (
 		<div
-			className={`w-[268px] h-[480px] overflow-hidden cursor-pointer rounded-[8px] 
-              flex flex-col items-center justify-center relative transition-all border 
-              ${isSelected ? "border-[10px] border-purple-500 shadow-lg" : "border border-gray-300"}`}
+			className={cn(
+				"w-[268px] h-[480px] overflow-hidden cursor-pointer rounded-[8px] flex flex-col items-center justify-center relative transition-all border",
+				isSelected ? "border-[10px] border-purple-500 shadow-lg" : "border border-gray-300",
+				className
+			)}
 			onClick={onClick}
-			data-thumbnail-id={thumbnailId} // ✅ 데이터 속성 추가 가능
-			data-art-style-id={artStyleId} // ✅ 데이터 속성 추가 가능
+			data-thumbnail-id={thumbnailId}
+			data-art-style-id={artStyleId}
 		>
 			{/* ✅ 배경 (이미지 위아래로 위치) */}
 			<div className="absolute top-0 left-0 w-full h-full bg-gray-5"></div>
 
 			{/* ✅ 제목 개행이 적용되도록 `white-space: pre-line;` 추가 */}
-			{/* ✅ 개행 적용 (한 줄에 최대 14자, 최대 3줄 유지) */}
 			<div className="absolute top-4 text-center font-bold text-lg text-white whitespace-pre-line">
 				{title || "기본 제목"}
 			</div>
 
 			{/* ✅ 이미지 (배경 위에서 수직 중앙 정렬) */}
 			<Image
-				//imageSrc가 undefined, null, ""(빈 문자열)일 경우 false가 되어 기본 이미지를 사용
 				src={imageSrc && imageSrc !== "" ? imageSrc : "/images/news-making/thumbnail-dummy.png"}
 				alt={altText}
 				width={268}

--- a/src/components/news-making/card/ThumbnailCard.tsx
+++ b/src/components/news-making/card/ThumbnailCard.tsx
@@ -7,22 +7,27 @@ interface ThumbnailCardProps {
 	title: string;
 	imageSrc: string;
 	altText: string;
-	textAlign: "left" | "center" | "right";
-	fontColor: string;
-	fontSize: number;
-	fontFamily: string;
+	textAlign?: "left" | "center" | "right";
+	fontColor?: string;
+	fontSize?: number;
+	fontFamily?: string;
 }
 
 export default function ThumbnailCard(props: ThumbnailCardProps) {
 	const { thumbnailId, artStyleId, title, imageSrc, altText, textAlign, fontColor, fontSize, fontFamily } = props;
 	const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const tempThumbnailId = thumbnailId;
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const tempArtStyleId = artStyleId;
+
+
 	useEffect(() => {
 		const canvas = canvasRef.current;
 		if (!canvas) return;
 		const ctx = canvas.getContext("2d");
 		if (!ctx) return;
-
 		// ✅ 캔버스 크기 설정
 		const canvasWidth = 265;
 		const canvasHeight = 108;
@@ -34,12 +39,12 @@ export default function ThumbnailCard(props: ThumbnailCardProps) {
 
 		// ✅ 텍스트 스타일 적용
 		ctx.font = `${fontSize}px ${fontFamily}`;
-		ctx.fillStyle = fontColor;
+		ctx.fillStyle = fontColor ?? 'black';
 		ctx.textAlign = textAlign as CanvasTextAlign;
 		ctx.textBaseline = "top";
 
 		// ✅ 최대 줄 수 제한 (현재 폰트 기준)
-		const lineHeight = fontSize * 1.2;
+		const lineHeight = ((fontSize ?? 3) * 1.2);
 		const maxLines = Math.floor(canvasHeight / lineHeight);
 		const maxWidth = canvasWidth - 40; // 좌우 여백 고려
 

--- a/src/components/news-making/card/ThumbnailCard.tsx
+++ b/src/components/news-making/card/ThumbnailCard.tsx
@@ -1,48 +1,82 @@
+import React, { useEffect, useRef } from "react";
 import Image from "next/image";
-import React from "react";
-import { cn } from "@/src/utils/cn"; // ✅ cn 함수 가져오기
 
 interface ThumbnailCardProps {
-	artStyleId: number;
 	thumbnailId: number;
+	artStyleId: number;
 	title: string;
-	imageSrc?: string;
+	imageSrc: string;
 	altText: string;
-	onClick?: () => void;
-	isSelected?: boolean;
-	className?: string;
+	textAlign: "left" | "center" | "right";
+	fontColor: string;
+	fontSize: number;
+	fontFamily: string;
 }
 
 export default function ThumbnailCard(props: ThumbnailCardProps) {
-	const { thumbnailId, artStyleId, title, imageSrc, altText, onClick, isSelected, className } = props;
+	const { thumbnailId, artStyleId, title, imageSrc, altText, textAlign, fontColor, fontSize, fontFamily } = props;
+	const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+	useEffect(() => {
+		const canvas = canvasRef.current;
+		if (!canvas) return;
+		const ctx = canvas.getContext("2d");
+		if (!ctx) return;
+
+		// ✅ 캔버스 크기 설정
+		const canvasWidth = 265;
+		const canvasHeight = 108;
+		canvas.width = canvasWidth;
+		canvas.height = canvasHeight;
+
+		// ✅ 기존 배경 유지 (div 배경은 그대로, 캔버스는 텍스트만 출력)
+		ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+		// ✅ 텍스트 스타일 적용
+		ctx.font = `${fontSize}px ${fontFamily}`;
+		ctx.fillStyle = fontColor;
+		ctx.textAlign = textAlign as CanvasTextAlign;
+		ctx.textBaseline = "top";
+
+		// ✅ 최대 줄 수 제한 (현재 폰트 기준)
+		const lineHeight = fontSize * 1.2;
+		const maxLines = Math.floor(canvasHeight / lineHeight);
+		const maxWidth = canvasWidth - 40; // 좌우 여백 고려
+
+		// ✅ 사용자가 입력한 줄바꿈(`\n`)을 그대로 유지
+		let lines = title.split("\n").slice(0, maxLines); // ✅ 초과된 줄 제거
+
+		// ✅ 각 줄별로 최대 너비 체크 후 잘라서 표시
+		lines = lines.map((line) => {
+			let shortenedLine = "";
+			for (const char of line) {
+				if (ctx.measureText(shortenedLine + char).width > maxWidth) break;
+				shortenedLine += char;
+			}
+			return shortenedLine;
+		});
+
+		// ✅ 줄별로 텍스트 그리기
+		lines.forEach((line, i) => {
+			const textX = textAlign === "left" ? 20 : textAlign === "right" ? canvas.width - 20 : canvas.width / 2;
+			const textY = 10 + i * lineHeight;
+			ctx.fillText(line, textX, textY);
+		});
+
+	}, [title, fontSize, fontColor, fontFamily, textAlign]);
 
 	return (
 		<div
-			className={cn(
-				"w-[268px] h-[480px] overflow-hidden cursor-pointer rounded-[8px] flex flex-col items-center justify-center relative transition-all border",
-				isSelected ? "border-[10px] border-purple-500 shadow-lg" : "border border-gray-300",
-				className
-			)}
-			onClick={onClick}
-			data-thumbnail-id={thumbnailId}
-			data-art-style-id={artStyleId}
+			className="relative w-[268px] h-[480px] overflow-hidden cursor-pointer rounded-[8px] flex flex-col items-center justify-center transition-all border border-gray-300"
 		>
-			{/* ✅ 배경 (이미지 위아래로 위치) */}
+			{/* ✅ 기존 배경 유지 */}
 			<div className="absolute top-0 left-0 w-full h-full bg-gray-5"></div>
 
-			{/* ✅ 제목 개행이 적용되도록 `white-space: pre-line;` 추가 */}
-			<div className="absolute top-4 text-center font-bold text-lg text-white whitespace-pre-line">
-				{title || "기본 제목"}
-			</div>
+			{/* ✅ 캔버스를 제목 텍스트로 사용 */}
+			<canvas ref={canvasRef} className="absolute top-4 left-0 w-full h-[108px] pointer-events-none" />
 
-			{/* ✅ 이미지 (배경 위에서 수직 중앙 정렬) */}
-			<Image
-				src={imageSrc && imageSrc !== "" ? imageSrc : "/images/news-making/thumbnail-dummy.png"}
-				alt={altText}
-				width={268}
-				height={224}
-				className="relative z-10 object-cover"
-			/>
+			{/* ✅ 이미지 */}
+			<Image src={imageSrc || "/images/news-making/thumbnail-dummy.png"} alt={altText} width={268} height={224} className="relative z-10 object-cover" />
 		</div>
 	);
 }

--- a/src/utils/aspect-ratio.tsx
+++ b/src/utils/aspect-ratio.tsx
@@ -1,0 +1,5 @@
+import * as AspectRatioPrimitive from "@radix-ui/react-aspect-ratio";
+
+const AspectRatio = AspectRatioPrimitive.Root;
+
+export { AspectRatio };

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+	return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## 🚀 PR 요약

<!-- 어떤 변경을 했는지 한 줄 요약해주세요
예시)
  - 다크 모드 기능 추가
  - 로그인 API 버그 수정
-->

- 컷 생성 페이지 제작에 따른 다른 페이지와 컴포넌트 변경

## 📌 작업 내용

<!-- 어떤 작업을 했는지 자세히 설명해주세요
예시)
  - 다크 모드 토글 버튼 추가
  - 사용자의 테마 설정을 로컬 스토리지에 저장
-->


- 아트 스타일 페이지 썸네일 링크 추가

- 썸네일 페이지 폰트 설정 추가 및 백엔드 img로 제목 전송을 위한 캔버스 변경
  - ThumbnailFontMenu 컴포넌트 추가 및 텍스트 편집 가능하게 변경
  - ThumbnailCard에 폰트 관련 props 추가(ThumbnailFontMenu와 동일)
  - ThumbnailFontMenu에 update함수 추가

- 썸네일 카드 컴포넌트에 캔버스 추가 후 텍스트 크기에 따라 길이와 높이 제한이 되도록 설정
  - 최대 줄 수 제한 설정 추가(lineHeight, maxLines, maxWidth)
  - 각 줄 별로 최대 너비 체크 후 잘라서 표시
  - 사용자가 입력한 개행 유지
  
- 추가 패키지 설치
    "@radix-ui/react-aspect-ratio": "^1.1.2",
    "@radix-ui/react-checkbox": "^1.1.4",
    "class-variance-authority": "^0.7.1",
    "clsx": "^2.1.1",
    "lucide-react": "^0.483.0",
    "tailwind-merge": "^3.0.2"

- cn 유틸 추가

- 음성 드롭다운의 텍스트 영역 사이즈 고정으로 변경

## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 입력해주세요 (#이슈번호를 입력하면 자동으로 하단에 이슈가 매칭됩니다 😀)
예시)
  - #3
  - #17
-->

- #38 

## 📷 변경 전/후 스크린샷 (선택)

<!-- UI 변경 사항이 있다면 스크린샷을 첨부해주세요 -->

![image](https://github.com/user-attachments/assets/ecc7f941-c748-4a76-a226-ddc8d81af87b)
![image](https://github.com/user-attachments/assets/7d701b23-bd0e-4020-93d3-c6cc5a36ce75)


## 📝 추가 정보 (선택)

<!-- PR과 관련하여 추가로 공유할 내용이 있다면 적어주세요
예시)
  - 배포 시 `.env` 설정 변경 필요
  - 관련 API 문서 업데이트 필요
-->
