### PR TITLE
[🚀 Feature] 백엔드 api 변경에 따른 생성 페이지 수정

### DIFF
--- a/src/app/(home)/news-making/create/page.tsx
+++ b/src/app/(home)/news-making/create/page.tsx
@@ -13,6 +13,7 @@ import { useProjectStore } from "@/src/store/useNewsMakingStore";
 import { ART_STYLES } from "@/src/constants/artStyles";
 import { useRouter } from "next/navigation";
 import { SectionContent } from "@/src/components/news-making/section/SectionContent";
+import { createProjectArtifact } from "@/src/components/news-making/api/CreateSectionAPI";
 
 interface ContentSection {
 	title: string;
@@ -40,14 +41,26 @@ export default function Element() {
 		}
 	}
 
-	const handleNextClick = () => {
-		if (thumbnailRef.current && currentProject) {
-			thumbnailRef.current.captureCard((dataUrl) => {
-				updateThumbnailImage(dataUrl);
+	const handleNextClick = async () => {
+		try {
+			if (!currentProjectId) {
+				console.error('No project ID available');
+				return;
+			}
+
+			if (thumbnailRef.current && currentProject) {
+				thumbnailRef.current.captureCard((dataUrl) => {
+					updateThumbnailImage(dataUrl);
+					createProjectArtifact(currentProjectId.toString()).then(() => {
+						router.push('/loading');
+					});
+				});
+			} else {
+				await createProjectArtifact(currentProjectId.toString());
 				router.push('/loading');
-			});
-		} else {
-			router.push('/loading');
+			}
+		} catch (error) {
+			console.error('Failed to create project artifact:', error);
 		}
 	};
 

--- a/src/app/(home)/news-making/create/page.tsx
+++ b/src/app/(home)/news-making/create/page.tsx
@@ -19,6 +19,7 @@ interface ContentSection {
 	buttonText: string;
 	hasCheckbox: boolean;
 	script: string;
+	backendSectionId?: number;
 }
 
 export default function Element() {
@@ -68,6 +69,12 @@ export default function Element() {
 	const handleScriptChange = (index: number, value: string) => {
 		setContentSections(prev => prev.map((section, i) => 
 			i === index ? { ...section, script: value } : section
+		));
+	};
+
+	const handleSectionIdUpdate = (index: number, backendSectionId: number) => {
+		setContentSections(prev => prev.map((section, i) => 
+			i === index ? { ...section, backendSectionId: backendSectionId } : section
 		));
 	};
 
@@ -154,6 +161,7 @@ export default function Element() {
 												title={section.title}
 												script={section.script}
 												onScriptChange={handleScriptChange}
+												onSectionIdUpdate={handleSectionIdUpdate}
 											/>
 										</div>
 									</div>

--- a/src/app/api/projects/[projectId]/route.ts
+++ b/src/app/api/projects/[projectId]/route.ts
@@ -35,3 +35,16 @@ export async function DELETE(req: NextRequest, context: { params: Promise<{ proj
     return handleApiError(error);
   }
 }
+
+// POST 요청 (아티팩트 생성)
+export async function POST(req: NextRequest, context: { params: Promise<{ projectId: string }> }) {
+  const { projectId } = await context.params;
+  try {
+    //const type = req.nextUrl.searchParams.get('type');
+
+    const response = await apiClient.post(`/projects/${projectId}?type=artifact`);
+    return new NextResponse(response.data, { status: 202 });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/src/components/news-making/VoiceDropdown.tsx
+++ b/src/components/news-making/VoiceDropdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef } from "react";
 import { ChevronDownIcon } from "lucide-react";
 import { Button } from "@/src/components/news-making/button/CommonNewsMakingButton";
 

--- a/src/components/news-making/api/CreateSectionAPI.ts
+++ b/src/components/news-making/api/CreateSectionAPI.ts
@@ -1,6 +1,5 @@
-import apiClient from '@/src/utils/apiClient';
 
-
+//todo 추후 api 클라이언트로 재 변경
 // interface CreateSectionResponse {
 //   id: number;
 // }
@@ -57,13 +56,53 @@ export const updateSection = async (
       body: body instanceof FormData ? body : JSON.stringify(body),
     });
 
-    if (!response.ok) {
-      throw new Error('Failed to update section');
-    }
-
     return response.json();
   } catch (error) {
     console.error('Error updating section:', error);
+    throw error;
+  }
+};
+
+export const createProject = async (projectId: string): Promise<void> => {
+  try {
+    const response = await fetch(`/api/projects/${projectId}?type=artifact`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to create project');
+    }
+
+    if (response.status !== 202) {
+      throw new Error('Unexpected response status');
+    }
+  } catch (error) {
+    console.error('Error creating project:', error);
+    throw error;
+  }
+};
+
+export const createProjectArtifact = async (projectId: string): Promise<void> => {
+  try {
+    const response = await fetch(`/api/projects/${projectId}?type=artifact`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to create project artifact');
+    }
+
+    if (response.status !== 202) {
+      throw new Error('Unexpected response status');
+    }
+  } catch (error) {
+    console.error('Error creating project artifact:', error);
     throw error;
   }
 }; 

--- a/src/components/news-making/api/CreateSectionAPI.ts
+++ b/src/components/news-making/api/CreateSectionAPI.ts
@@ -1,41 +1,69 @@
 import apiClient from '@/src/utils/apiClient';
 
-interface CreateSectionResponse {
-  id: number;
+
+// interface CreateSectionResponse {
+//   id: number;
+// }
+
+// export const createSection = async (projectId: string): Promise<CreateSectionResponse> => {
+//   try {
+//     const response = await apiClient.post<CreateSectionResponse>(
+//       `/api/projects/${projectId}/sections`
+//     );
+//     return response.data;
+//   } catch (error) {
+//     console.error('Failed to create section:', error);
+//     throw error;
+//   }
+// };
+
+interface UpdateSectionBody {
+  voiceModel?: string;
+  alt?: string;
+  script?: string;
+  transitionName?: string;
+  prompt?: string;
 }
 
-export const createSection = async (projectId: string): Promise<CreateSectionResponse> => {
-  try {
-    const response = await apiClient.post<CreateSectionResponse>(
-      `/api/projects/${projectId}/sections`
-    );
-    return response.data;
-  } catch (error) {
-    console.error('Failed to create section:', error);
-    throw error;
-  }
-};
+interface UpdateSectionResponse {
+  id: number;
+  script?: string;
+  sortOrder?: number;
+  contentUrl?: string;
+  audioUrl?: string;
+  videoUrl?: string;
+  alt?: string;
+  voiceModel?: string;
+  transitionUrl?: string;
+  imageUrl?: string;
+}
 
 export const updateSection = async (
-  projectId: string,
-  sectionId: string,
-  data: { prompt: string } | FormData
-) => {
+  projectId: string, 
+  body: UpdateSectionBody | FormData
+): Promise<UpdateSectionResponse> => {
   try {
-    const response = await apiClient.post(
-      `/api/projects/${projectId}/sections/${sectionId}`,
-      data,
-      {
-        headers: data instanceof FormData ? {
-          'Content-Type': 'multipart/form-data',
-        } : {
-          'Content-Type': 'application/json',
-        },
-      }
-    );
-    return response.data;
+    const headers: HeadersInit = {
+      'Accept': 'application/json',
+    };
+
+    if (!(body instanceof FormData)) {
+      headers['Content-Type'] = 'application/json';
+    }
+
+    const response = await fetch(`/api/projects/${projectId}/sections`, {
+      method: 'POST',
+      headers,
+      body: body instanceof FormData ? body : JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to update section');
+    }
+
+    return response.json();
   } catch (error) {
-    console.error('Failed to update section:', error);
+    console.error('Error updating section:', error);
     throw error;
   }
 }; 

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -55,29 +55,29 @@ export const handlers = [
     );
   }),
   // 섹션만 생성
-  http.post(`${API_URL}/projects/:projectId/sections`, async ({ request }) => {
-    console.log('🔵 MSW Intercepted - POST /projects/:projectId/sections');
-    console.log('Request URL:', request.url);
-    console.log('Request Headers:', Object.fromEntries(request.headers.entries()));
-    const headers = Object.fromEntries(request.headers.entries());
-    return new HttpResponse(
-      JSON.stringify({ 
-        id: getNextSectionId(),
-        script: "string",
-        sortOrder: 1,
-        resourceUrl: "string",
-        audioUrl: "string",
-        videoUrl: "string"
-      }),
-      {
-        status: 201,
-        headers: {
-          'Content-Type': 'application/json',
-          'Set-Cookie': `Authorization=${headers.authorization}; Path=/; HttpOnly; SameSite=Lax`
-        }
-      }
-    );
-  }),
+  // http.post(`${API_URL}/projects/:projectId/sections`, async ({ request }) => {
+  //   console.log('🔵 MSW Intercepted - POST /projects/:projectId/sections');
+  //   console.log('Request URL:', request.url);
+  //   console.log('Request Headers:', Object.fromEntries(request.headers.entries()));
+  //   const headers = Object.fromEntries(request.headers.entries());
+  //   return new HttpResponse(
+  //     JSON.stringify({ 
+  //       id: getNextSectionId(),
+  //       script: "string",
+  //       sortOrder: 1,
+  //       resourceUrl: "string",
+  //       audioUrl: "string",
+  //       videoUrl: "string"
+  //     }),
+  //     {
+  //       status: 201,
+  //       headers: {
+  //         'Content-Type': 'application/json',
+  //         'Set-Cookie': `Authorization=${headers.authorization}; Path=/; HttpOnly; SameSite=Lax`
+  //       }
+  //     }
+  //   );
+  // }),
 
   // 프로젝트 생성 API
   http.post(`${API_URL}/projects`, async ({ request }) => {
@@ -115,8 +115,8 @@ export const handlers = [
     );
   }),
 
-  http.post(`${API_URL}/projects/:projectId/sections/:sectionId`, async ({ request }) => {
-    console.log('🔵 MSW Intercepted - POST /projects/:projectId/sections/:sectionId');
+  http.post(`${API_URL}/projects/:projectId/sections`, async ({ request }) => {
+    console.log('🔵 MSW Intercepted - POST /projects/:projectId/sections');
     console.log('Request URL:', request.url);
     //console.log('Request Headers:', Object.fromEntries(request.headers.entries()));
 
@@ -132,6 +132,7 @@ export const handlers = [
       const transitionName = formData.get('transitionName');
       console.log('FormData:', formData.get('script'));
       return HttpResponse.json({
+        id: getNextSectionId(),
         imageUrl: 'https://i.imgur.com/P2ruiUz.jpeg',
         alt: alt || '고양이 사진',
         script: script || '고양이를 키울 때 알고 있어야 할 주의사항에 대해 알아보겠습니다.',
@@ -142,6 +143,7 @@ export const handlers = [
     } else {
       console.log('핸들러 로그 : 📤 JSON 요청 처리');
       const bodyData = await request.json() as {
+        id: number;
         alt?: string;
         script?: string;
         voiceModel?: string;
@@ -152,7 +154,7 @@ export const handlers = [
       console.log('🔄 요청 바디 : ', bodyData);
       return new HttpResponse(
         JSON.stringify({
-          id: Math.floor(Math.random() * 1000) + 1,
+          id: getNextSectionId(),
           imageUrl: 'https://i.imgur.com/P2ruiUz.jpeg',
           alt: alt || '대체 텍스트',
           script: `'${script}' 내용을 기반으로 AI가 생성한 이미지`,

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -264,4 +264,16 @@ export const handlers = [
       { status: 400 }
     );
   }),
+
+  // 프로젝트 아티팩트 생성 API
+  http.post(`${API_URL}/projects/:projectId`, async ({ params, request }) => {
+    const { projectId } = params;
+    const url = new URL(request.url);
+    const type = url.searchParams.get('type');
+
+    console.log('🔵 MSW Intercepted - POST /projects/:projectId');
+    console.log('projectId:', projectId);
+    console.log('type:', type);
+    return new HttpResponse(null, { status: 202 });
+  }),
 ];


### PR DESCRIPTION
## 🚀 PR 요약

<!-- 어떤 변경을 했는지 한 줄 요약해주세요
예시)
  - 다크 모드 기능 추가
  - 로그인 API 버그 수정
-->

- 백엔드 api 변경에 따른 생성 페이지 수정

## 📌 작업 내용

<!-- 어떤 작업을 했는지 자세히 설명해주세요
예시)
  - 다크 모드 토글 버튼 추가
  - 사용자의 테마 설정을 로컬 스토리지에 저장
-->

### feat: 생성 페이지 섹션 업데이트 API 수정 및 FormData 처리 개선
- 섹션 업데이트 API 메서드를 PATCH에서 POST로 변경
- FormData 처리 로직 개선
  - FormData 사용 시 Content-Type 헤더 자동 설정되도록 수정
  - JSON 데이터 전송 시에만 Content-Type 헤더 명시적 설정
- API 응답 타입 정의 개선
  - UpdateSectionResponse 인터페이스에 필요한 필드 추가
  - FormData와 JSON 요청 모두 지원하도록 수정
- api 변경에 따른 핸들러 수정

### feat: 프로젝트 아티팩트 생성 API 엔드포인트 추가
- /api/projects/[projectId] POST 엔드포인트 추가
  - 아티팩트 생성을 위한 POST 요청 처리
  - type=artifact 쿼리 파라미터로 요청 구분
  - 202 Accepted 상태 코드 반환

- 생성 페이지에서 다음으로 버튼 클릭 시 호출

- 핸들러 추가

## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 입력해주세요 (#이슈번호를 입력하면 자동으로 하단에 이슈가 매칭됩니다 😀)
예시)
  - #3
  - #17
-->

- #72 

## 📷 변경 전/후 스크린샷 (선택)

<!-- UI 변경 사항이 있다면 스크린샷을 첨부해주세요 -->

## 📝 추가 정보 (선택)

<!-- PR과 관련하여 추가로 공유할 내용이 있다면 적어주세요
예시)
  - 배포 시 `.env` 설정 변경 필요
  - 관련 API 문서 업데이트 필요
-->
