### PR TITLE
[🚀 Fix] 마이페이지 이름, 번호 get 수정 

### DIFF
--- a/src/app/(home)/mypage/page.tsx
+++ b/src/app/(home)/mypage/page.tsx
@@ -1,49 +1,65 @@
 "use client";
 
 import React, { JSX, useEffect, useState } from "react";
-import Cookies from "js-cookie";
 import { Card, CardContent } from "@/src/components/common/Card";
 import TossPaymentButton from "@/src/components/toss/Payment";
 import LogoutButton from "@/src/components/auth/Logout";
+import EditProfileButton from "@/src/components/auth/EditProfile";
+import apiClient from "@/src/utils/apiClient";
 
 interface MemberData {
   name: string;
   phoneNumber: string;
 }
 
-const dummyToken =
-  "eyJraWQiOiJyc2EtcHJvZC1rZXktaWQiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxIiwiZXhwIjoxNzQzODQxMDM1LCJpYXQiOjE3NDMyMzYyMzUsInBsYW4iOiJCQVNJQyIsImVtYWlsIjoia216MDQxNDAxQGdtYWlsLmNvbSJ9.KwAsjfUofsMi-5MbsdqAohSAWC3tEHd521s9kc6xRGnSVHWQcGJnxzOvuVJQfc5974HTDGVt0saGewSSFxHbaefzh7FacZ5T3NVpk7SRDuwBFrPqnenp8QWW_rYyjq_FrjjYAFb-oZZeEdN3w02Jq51bq6OGVwBAK7PKxjD2S2XjXhvLZcUmd2eZbLteQ7LAPKtLe4Ir50xCLwTU-0fcWBx-2TuqbMevFXfPgtb8Y9aTqIieC_0YmyG6MAFTv4gW-OFoy6m8jJSBpuJ8gtSgos1P6yruYBisAfC4_r2wYwJVCnWCUDVCLs_GvtuhIlCGMvpyyFZOM-QHJ-LMGXCD3A";
-
 export default function MyPage(): JSX.Element {
   const [memberData, setMemberData] = useState<MemberData>({
     name: "정보없음",
     phoneNumber: "정보없음",
   });
-  const token = Cookies.get("Authorization") ? 0 : dummyToken;
 
   useEffect(() => {
-    fetch("https://api.unicat.day/members", {
-      method: "GET",
-      headers: {
-        Accept: "*/*",
-        Authorization: `Bearer ${token}`,
-      },
-    })
-      .then((response) => response.json())
-      .then((data) => {
+    apiClient
+      .get("https://api.unicat.day/members", {})
+      .then((response) => {
+        const data = response.data;
+        console.log(data);
         setMemberData({
-          name: data.name ? data.name : "정보없음",
-          phoneNumber: data.phoneNumber ? data.phoneNumber : "정보없음",
+          name: data.name || "정보없음",
+          phoneNumber: data.phoneNumber || "정보없음",
         });
+      })
+      .catch((error) => {
+        console.error("멤버 정보 가져오기 실패:", error);
       });
-  }, [token]);
+  }, []);
+
+  const fetchMemberData = () => {
+    apiClient
+      .get("https://api.unicat.day/members", {})
+      .then((response) => {
+        const data = response.data;
+        setMemberData({
+          name: data.name || "정보없음",
+          phoneNumber: data.phoneNumber || "정보없음",
+        });
+      })
+      .catch((error) => {
+        console.error("멤버 정보 가져오기 실패:", error);
+      });
+  };
+
+  useEffect(() => {
+    fetchMemberData();
+  }, []);
 
   return (
-    <div className="flex flex-col items-center justify-center gap-[90px] relative bg-purple-6 min-h-screen">
+    <div className="flex flex-col items-center justify-center gap-[90px] relative mt-10">
       <main className="flex flex-col w-full max-w-[700px] items-center gap-6 relative flex-[0_0_auto]">
         <h1 className="font-bold-24 text-gray-5 font-bold text-[length:var(--bold-24-font-size)] tracking-[var(--bold-24-letter-spacing)] leading-[var(--bold-24-line-height)] self-start">
           마이페이지
         </h1>
+
         <Card className="w-[700px] bg-white rounded-2xl border border-solid border-gray-1 shadow-[0px_1px_8px_2px_#0000000a] mx-auto">
           <CardContent className="flex flex-col w-full px-6 py-6">
             <div className="flex flex-col mb-10">
@@ -76,7 +92,14 @@ export default function MyPage(): JSX.Element {
               </button>
             </div>
             <div className="w-full h-px bg-gray-4 my-4"></div>
-            <LogoutButton token={token} />
+            <div className="flex items-center ">
+              <LogoutButton />
+              <EditProfileButton
+                initialName={memberData.name}
+                initialPhoneNumber={memberData.phoneNumber}
+                onUpdate={fetchMemberData}
+              />
+            </div>
           </CardContent>
         </Card>
       </main>

--- a/src/app/(home)/playing/page.tsx
+++ b/src/app/(home)/playing/page.tsx
@@ -3,11 +3,11 @@
 import React from "react";
 
 const dummyVideoUrl =
-  "https://bhqvrnbzzqzqlwwrcgbm.supabase.co/storage/v1/object/public/video/uploads/f108e375-9130-4cb5-84c1-89c95249cb7f.mp4";
+  "https://bhqvrnbzzqzqlwwrcgbm.supabase.co/storage/v1/object/video/unicat_uploads1378179665791900146.mp4";
 
 export default function VideoPlayer() {
   return (
-    <div className="flex flex-col items-center min-h-screen">
+    <div className="flex flex-col items-center mt-10 min-h-screen">
       <div className="h-[90vh] w-auto">
         <video
           className="h-full rounded-lg"

--- a/src/app/(home)/statistics/page.tsx
+++ b/src/app/(home)/statistics/page.tsx
@@ -19,7 +19,7 @@ const dummyAnalyticsData = {
   datasets: [
     {
       label: "조회수",
-      data: [120, 190, 300, 500, 220, 330, 410, 290, 370, 450, 390, 480],
+      data: [120, 190, 300, 482, 220, 330, 410, 290, 370, 450, 390, 480],
       backgroundColor: "rgba(75, 192, 192, 0.5)",
     },
     {
@@ -37,15 +37,14 @@ const dummyAnalyticsData = {
 
 export default function YoutubeAnalytics() {
   return (
-    <div className="flex flex-col items-center min-h-screen mt-[205px] gap-[40px]">
+    <div className="flex flex-col items-center min-h-screen mt-10 gap-[40px]">
       <header className="flex w-full items-center justify-between">
         <h1 className="text-gray-5 font-bold-24 text-[24px] font-bold leading-[28px]">
           YouTube 통계
         </h1>
       </header>
 
-      {/* 그래프 */}
-      <div className="w-full max-w-[800px]">
+      <div className="w-[1000px] h-[400px]">
         <Bar
           data={dummyAnalyticsData}
           options={{ responsive: true, maintainAspectRatio: false }}

--- a/src/components/auth/EditProfile.tsx
+++ b/src/components/auth/EditProfile.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import React, { useState } from "react";
+import apiClient from "@/src/utils/apiClient";
+
+interface EditProfileButtonProps {
+  initialName: string;
+  initialPhoneNumber: string;
+  onUpdate: () => void;
+}
+
+export default function EditProfileButton({
+  initialName,
+  initialPhoneNumber,
+  onUpdate,
+}: EditProfileButtonProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [name, setName] = useState(initialName);
+  const [phoneNumber, setPhoneNumber] = useState(initialPhoneNumber);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+
+    try {
+      await apiClient.patch("https://api.unicat.day/members", {
+        name,
+        phoneNumber,
+      });
+      setIsOpen(false);
+      onUpdate();
+      alert("회원 정보가 성공적으로 수정되었습니다.");
+    } catch (error) {
+      console.error("회원 정보 수정 실패:", error);
+      alert("회원 정보 수정에 실패했습니다.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <button
+        onClick={() => setIsOpen(true)}
+        className="w-[100px] h-[40px] bg-gray-400 rounded-lg text-white hover:bg-gray-700 flex ml-5 items-center justify-center">
+        정보수정
+      </button>
+
+      {isOpen && (
+        <div className="fixed inset-0 bg-gray-800 bg-opacity-70 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg p-6 w-[400px]">
+            <h2 className="text-xl font-bold mb-4">회원 정보 수정</h2>
+            <form onSubmit={handleSubmit}>
+              <div className="mb-4">
+                <label className="block text-gray-5 font-medium mb-2">이름</label>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  className="w-full p-2 border border-gray-300 rounded"
+                  required
+                />
+              </div>
+              <div className="mb-6">
+                <label className="block text-gray-5 font-medium mb-2">전화번호</label>
+                <input
+                  type="tel"
+                  value={phoneNumber}
+                  onChange={(e) => setPhoneNumber(e.target.value)}
+                  className="w-full p-2 border border-gray-300 rounded"
+                  required
+                  pattern="[0-9]{10,11}"
+                  placeholder="'-' 없이 숫자만 입력"
+                />
+              </div>
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={() => setIsOpen(false)}
+                  className="px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400"
+                  disabled={isSubmitting}>
+                  취소
+                </button>
+                <button
+                  type="submit"
+                  className="px-4 py-2 bg-purple-500 text-white rounded hover:bg-purple-700"
+                  disabled={isSubmitting}>
+                  {isSubmitting ? "처리 중..." : "저장"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/auth/Logout.tsx
+++ b/src/components/auth/Logout.tsx
@@ -1,23 +1,15 @@
+// Logout.tsx 수정 버전
 "use client";
 
-import axios from "axios";
+import apiClient from "@/src/utils/apiClient"; // axios 대신 apiClient 임포트
 
-interface LogoutButtonProps {
-  token: string | number;
-}
-
-export default function LogoutButton({ token }: LogoutButtonProps) {
+export default function LogoutButton() {
   const handleLogout = async () => {
     const confirmed = window.confirm("정말 로그아웃 하시겠습니까?");
     if (!confirmed) return;
 
     try {
-      await axios.delete("https://api.unicat.day/auth/sign-out", {
-        headers: {
-          accept: "*/*",
-          Authorization: `Bearer ${token}`,
-        },
-      });
+      await apiClient.delete("https://api.unicat.day/auth/sign-out", {}); // 헤더 생략
       alert("로그아웃이 완료되었습니다.");
       window.location.href = "/login";
     } catch (error) {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -14,10 +14,9 @@ import Link from "next/link";
 interface HeaderProps {
   className?: string; // ✅ className을 props로 받을 수 있도록 추가
 }
-
 const navigationItems = [
-  { id: "dashboard", label: "대시보드", active: true },
-  { id: "statistics", label: "통계", active: false },
+  { id: "dashboard", label: "대시보드", href: "/" },
+  { id: "statistics", label: "통계", href: "/statistics" },
 ];
 
 const Header: React.FC<HeaderProps> = ({ className }) => {
@@ -27,16 +26,16 @@ const Header: React.FC<HeaderProps> = ({ className }) => {
         <div className="container flex items-center justify-between h-full max-w-[1200px] mx-auto px-4">
           <div className="flex items-center gap-11">
             {/* Logo */}
-              <Link href="/">
-                <Image
-                  alt="AINEWS"
-                  src="/images/logo.png"
-                  width={127}
-                  height={24}
-                  priority
-                  className="cursor-pointer"
-                />
-              </Link>
+            <Link href="/">
+              <Image
+                alt="AINEWS"
+                src="/images/logo.png"
+                width={127}
+                height={24}
+                priority
+                className="cursor-pointer"
+              />
+            </Link>
 
             {/* Navigation */}
             <NavigationMenu>
@@ -46,7 +45,7 @@ const Header: React.FC<HeaderProps> = ({ className }) => {
                     key={item.id}
                     className="relative">
                     <NavigationMenuLink
-                      href={`#${item.id}`}
+                      href={item.href}
                       className="text-gray-5 font-bold text-[24px]">
                       {item.label}
                     </NavigationMenuLink>


### PR DESCRIPTION
## 🚀 PR 요약

<!-- 어떤 변경을 했는지 한 줄 요약해주세요
예시)
  - 다크 모드 기능 추가
  - 로그인 API 버그 수정
-->

- apiClient 사용해서 로그인 정보 불러오기
- 카카오톡, 구글로 회원가입 시 이름, 전화번호가 없어 
해당 정보를 수정하기 위한 버튼을 추가하였으나 완전히 구현되지 않아서 수정이 필요함.

## 📌 작업 내용

<!-- 어떤 작업을 했는지 자세히 설명해주세요
예시)
  - 다크 모드 토글 버튼 추가
  - 사용자의 테마 설정을 로컬 스토리지에 저장
-->

- 마이페이지의 이름, 전화번호 로그인 정보에 맞춰서 불러오기 
- 로그아웃 버튼 수정

## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 입력해주세요 (#이슈번호를 입력하면 자동으로 하단에 이슈가 매칭됩니다 😀)
예시)
  -
  - #17
-->

- #15 
 