### PR TITLE
[🚀 Feature] 비로그인 유저 로그인 화면으로 리다이렉트

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -7,9 +7,11 @@ import {
   NavigationMenuList,
 } from "@/src/components/common/navigation-menu";
 import SubscribeButton from "@/src/components/news-making/button/SubscribeButton";
-import React from "react";
+import React, { useEffect } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import apiClient from "@/src/utils/apiClient";
 
 interface HeaderProps {
   className?: string; // ✅ className을 props로 받을 수 있도록 추가
@@ -20,6 +22,19 @@ const navigationItems = [
 ];
 
 const Header: React.FC<HeaderProps> = ({ className }) => {
+  const router = useRouter();
+  useEffect(() => {
+    apiClient
+      .get("https://api.unicat.day/members", {})
+      .then((response) => {
+        console.log("로그인 확인 성공:", response.data);
+      })
+      .catch((error) => {
+        console.error("로그인 확인 실패:", error);
+        router.replace("/login");
+      });
+  }, [router]);
+
   return (
     <header className={`flex flex-col items-center w-full border-b border-[#ECECEC] ${className}`}>
       <div className="w-full h-[100px] bg-white border-b border-[#ECECEC]">


### PR DESCRIPTION
## 🚀 PR 요약

<!-- 어떤 변경을 했는지 한 줄 요약해주세요
예시)
  - 다크 모드 기능 추가
  - 로그인 API 버그 수정
-->

- 비로그인 유저 로그인 화면으로 리다이렉트

## 📌 작업 내용

<!-- 어떤 작업을 했는지 자세히 설명해주세요
예시)
  - 다크 모드 토글 버튼 추가
  - 사용자의 테마 설정을 로컬 스토리지에 저장
-->

- 비로그인 유저 로그인 화면으로 리다이렉트

## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 입력해주세요 (#이슈번호를 입력하면 자동으로 하단에 이슈가 매칭됩니다 😀)
예시)
  - #3
  - #17
-->

- #83 

## 📷 변경 전/후 스크린샷 (선택)

<!-- UI 변경 사항이 있다면 스크린샷을 첨부해주세요 -->

## 📝 추가 정보 (선택)

<!-- PR과 관련하여 추가로 공유할 내용이 있다면 적어주세요
예시)
  - 배포 시 `.env` 설정 변경 필요
  - 관련 API 문서 업데이트 필요
-->
